### PR TITLE
Found incorrect behavior (I think). Wrote some tests.

### DIFF
--- a/src/owyl/core.py
+++ b/src/owyl/core.py
@@ -14,6 +14,7 @@ __date__ = "$Date$"[7:-2]
 
 import logging
 from collections import OrderedDict
+from functools import wraps
 
 try:
     from mx.Stack import Stack, EmptyError
@@ -33,19 +34,13 @@ __all__ = ['wrap', 'task', 'taskmethod', 'parent_task', 'parent_taskmethod', 'vi
 def wrap(func, *args, **kwargs):
     """Wrap a callable as a task. Yield the boolean of its result.
     """
+    @wraps(func)
     def initTask(**initkwargs):
+        @wraps(func)
         def makeIterator(**runkwargs):
             result = func(*args, **kwargs)
             yield bool(result)
-        try: makeIterator.__name__ = func.__name__
-        except AttributeError: pass
-        try: makeIterator.__doc__ = func.__doc__
-        except AttributeError: pass
         return makeIterator
-    try: initTask.__doc__ = func.__doc__
-    except AttributeError: pass
-    try: initTask.__name__ = func.__name__
-    except AttributeError: pass
     return initTask
 
 
@@ -55,20 +50,14 @@ def task(func):
     Decorate a generator function to produce a re-usable generator
     factory for the given task.
     """
+    @wraps(func)
     def initTask(**initkwargs):
+        @wraps(func)
         def makeIterator(**runkwargs):
             runkwargs.update(initkwargs)
             iterator = func(**runkwargs)
             return iterator
-        try: makeIterator.__name__ = func.__name__
-        except AttributeError: pass
-        try: makeIterator.__doc__ = func.__doc__
-        except AttributeError: pass
         return makeIterator
-    try: initTask.__doc__ = func.__doc__
-    except AttributeError: pass
-    try: initTask.__name__ = func.__name__
-    except AttributeError: pass
     return initTask
 
 
@@ -78,20 +67,14 @@ def taskmethod(func):
     Decorate a generator function to produce a re-usable generator
     factory for the given task.
     """
+    @wraps(func)
     def initTask(self, **initkwargs):
+        @wraps(func)
         def makeIterator(**runkwargs):
             runkwargs.update(initkwargs)
             iterator = func(self, **runkwargs)
             return iterator
-        try: makeIterator.__name__ = func.__name__
-        except AttributeError: pass
-        try: makeIterator.__doc__ = func.__doc__
-        except AttributeError: pass
         return makeIterator
-    try: initTask.__doc__ = func.__doc__
-    except AttributeError: pass
-    try: initTask.__name__ = func.__name__
-    except AttributeError: pass
     return initTask
 
 
@@ -103,20 +86,14 @@ def parent_task(func):
     Decorate a generator function to produce a re-usable generator
     factory for the given task.
     """
+    @wraps(func)
     def initTask(*children, **initkwargs):
+        @wraps(func)
         def makeIterator(**runkwargs):
             runkwargs.update(initkwargs)
             iterator = func(*children, **runkwargs)
             return iterator
-        try: makeIterator.__name__ = func.__name__
-        except AttributeError: pass
-        try: makeIterator.__doc__ = func.__doc__
-        except AttributeError: pass
         return makeIterator
-    try: initTask.__doc__ = func.__doc__
-    except AttributeError: pass
-    try: initTask.__name__ = func.__name__
-    except AttributeError: pass
     return initTask
 
 
@@ -128,20 +105,14 @@ def parent_taskmethod(func):
     Decorate a generator function to produce a re-usable generator
     factory for the given task.
     """
+    @wraps(func)
     def initTask(self, *children, **initkwargs):
+        @wraps(func)
         def makeIterator(**runkwargs):
             runkwargs.update(initkwargs)
             iterator = func(self, *children, **runkwargs)
             return iterator
-        try: makeIterator.__name__ = func.__name__
-        except AttributeError: pass
-        try: makeIterator.__doc__ = func.__doc__
-        except AttributeError: pass
         return makeIterator
-    try: initTask.__doc__ = func.__doc__
-    except AttributeError: pass
-    try: initTask.__name__ = func.__name__
-    except AttributeError: pass
     return initTask
 
 

--- a/src/owyl/decorators.py
+++ b/src/owyl/decorators.py
@@ -47,19 +47,8 @@ def flip(child, **kwargs):
 def repeatAlways(child, **kwargs):
     """Perpetually iterate over the child, regardless of return value.
     """
-    result = None
     while True:
-        try:
-            visitor = core.visit(child, **kwargs)
-        except StopIteration:
-            continue
-        while result is None:
-            try:
-                result = (yield visitor.next())
-            except StopIteration:
-                yield None
-                break
-        
+        yield child(**kwargs)
 
 @core.parent_task
 def repeatUntilFail(child, **kwargs):
@@ -69,18 +58,10 @@ def repeatUntilFail(child, **kwargs):
     @type final_value: C{True} or C{False}
     """
     final_value = kwargs.pop('final_value', False)
-    result = None
-    child = child(**kwargs)
-    while result is None:
-        try:
-            result = (yield child)
-            if result is False:
-                break
-            else:
-                yield None # Yield to other tasks.
-                result = None
-        except StopIteration:
-            result = None
+    while True:
+        result = (yield child(**kwargs))
+        if result is False:
+            break
     yield final_value
 
 @core.parent_task
@@ -90,19 +71,11 @@ def repeatUntilSucceed(child, **kwargs):
     @keyword final_value: Value to return on failure.
     @type final_value: C{True} or C{False}
     """
-    final_value = kwargs.pop('final_value', True)
-    result = None
-    child = child(**kwargs)
-    while result is None:
-        try:
-            result = (yield child)
-            if result is True:
-                break
-            else:
-                yield None # Yield to other tasks.
-                result = None
-        except StopIteration:
-            result = None
+    final_value = kwargs.pop('final_value', False)
+    while True:
+        result = (yield child(**kwargs))
+        if result is True:
+            break
     yield final_value
 
 @core.parent_task

--- a/tests/testowyl.py
+++ b/tests/testowyl.py
@@ -185,6 +185,38 @@ class OwylTests(unittest.TestCase):
         results = [x for x in v if x is not None]
         self.assertEqual(results, [False])
 
+    def testParallel_DelayedFailure(self):
+        """Can parallel fail if child fails later (all succeed)?
+        """
+        # Fail after 5 iterations.
+        after = 5
+        tree = owyl.parallel(owyl.succeed(),
+                             owyl.failAfter(after=after),
+                             policy=owyl.PARALLEL_SUCCESS.REQUIRE_ALL)
+        v = owyl.visit(tree)
+        results = [x for x in v if x is not None]
+        self.assertEqual(results, [False])
+
+        v = owyl.visit(tree)
+        results = [x for x in v if x is not None]
+        self.assertEqual(results, [False])
+
+    def testParallel_DelayedSuccess(self):
+        """Can parallel succeed if child succeeds later (one succeeds)?
+        """
+        # Succeed after 5 iterations.
+        after = 5
+        tree = owyl.parallel(owyl.fail(),
+                             owyl.succeedAfter(after=after),
+                             policy=owyl.PARALLEL_SUCCESS.REQUIRE_ONE)
+        v = owyl.visit(tree)
+        results = [x for x in v if x is not None]
+        self.assertEqual(results, [True])
+
+        v = owyl.visit(tree)
+        results = [x for x in v if x is not None]
+        self.assertEqual(results, [True])
+
     def testThrow(self):
         """Can we throw an exception within the tree?
         """

--- a/tests/testowyl.py
+++ b/tests/testowyl.py
@@ -424,6 +424,84 @@ class OwylTests(unittest.TestCase):
         result = results[-1]
         self.assertEqual(result, True)
 
+    def testRepeatUntilSucceed_Count(self):
+        """Does repeatUntilSucceed execute its child with every tick?
+        """
+        # How many times to repeat the behavior?
+        ticks = 100
+        bb = blackboard.Blackboard('test', count=0)
+
+        @owyl.task
+        def increment(**kwargs):
+            bb, key = kwargs['blackboard'], kwargs['key']
+            bb[key] += 1
+            yield False
+
+        tree = owyl.repeatUntilSucceed(increment(key='count'))
+        v = owyl.visit(tree, blackboard=bb)
+        for i in xrange(ticks):
+          v.next()
+        self.assertEqual(bb['count'], ticks)
+
+        # Need to reset the blackboard to get the same results.
+        bb = blackboard.Blackboard('test', count=0)
+        v = owyl.visit(tree, blackboard=bb)
+        for i in xrange(ticks):
+          v.next()
+        self.assertEqual(bb['count'], ticks)
+
+    def testRepeatUntilFail_Count(self):
+        """Does repeatUntilFail execute its child with every tick?
+        """
+        # How many times to repeat the behavior?
+        ticks = 100
+        bb = blackboard.Blackboard('test', count=0)
+
+        @owyl.task
+        def increment(**kwargs):
+            bb, key = kwargs['blackboard'], kwargs['key']
+            bb[key] += 1
+            yield True
+
+        tree = owyl.repeatUntilFail(increment(key='count'))
+        v = owyl.visit(tree, blackboard=bb)
+        for i in xrange(ticks):
+          v.next()
+        self.assertEqual(bb['count'], ticks)
+
+        # Need to reset the blackboard to get the same results.
+        bb = blackboard.Blackboard('test', count=0)
+        v = owyl.visit(tree, blackboard=bb)
+        for i in xrange(ticks):
+          v.next()
+        self.assertEqual(bb['count'], ticks)
+
+    def testRepeatAlways_Count(self):
+        """Does repeatAlways execute its child with every tick?
+        """
+        # How many times to repeat the behavior?
+        ticks = 100
+        bb = blackboard.Blackboard('test', count=0)
+
+        @owyl.task
+        def increment(**kwargs):
+            bb, key = kwargs['blackboard'], kwargs['key']
+            bb[key] += 1
+            yield True
+
+        tree = owyl.repeatAlways(increment(key='count'))
+        v = owyl.visit(tree, blackboard=bb)
+        for i in xrange(ticks):
+          v.next()
+        self.assertEqual(bb['count'], ticks)
+
+        # Need to reset the blackboard to get the same results.
+        bb = blackboard.Blackboard('test', count=0)
+        v = owyl.visit(tree, blackboard=bb)
+        for i in xrange(ticks):
+          v.next()
+        self.assertEqual(bb['count'], ticks)
+
 
 if __name__ == "__main__":
     runner = unittest

--- a/tests/testowyl.py
+++ b/tests/testowyl.py
@@ -82,7 +82,7 @@ class OwylTests(unittest.TestCase):
 
         results = [x for x in v if x is not None]
         self.assertEqual(results, [True, True, False, False])
-        
+
     def testVisitSelectorSuccess(self):
         """Can we visit a successful selector?
         """
@@ -242,7 +242,7 @@ class OwylTests(unittest.TestCase):
                              owyl.succeed(),
                              owyl.catch(owyl.throw(throws=ValueError,
                                                    throws_message="AUGH!!"),
-                                        caught=ValueError, 
+                                        caught=ValueError,
                                         branch=owyl.succeed())
                              )
         v = owyl.visit(tree)
@@ -262,7 +262,7 @@ class OwylTests(unittest.TestCase):
                              owyl.succeed(),
                              owyl.catch(owyl.throw(throws=ValueError,
                                                    throws_message="AUGH!!"),
-                                        caught=IndexError, 
+                                        caught=IndexError,
                                         branch=owyl.succeed())
                              )
         v = owyl.visit(tree)
@@ -313,7 +313,7 @@ class OwylTests(unittest.TestCase):
         bb = blackboard.Blackboard('test', value=value)
         tree = blackboard.checkBB(key='value',
                                   check=checker)
-        
+
         # Note that we can pass in the blackboard at run-time.
         v = owyl.visit(tree, blackboard=bb)
 
@@ -344,7 +344,7 @@ class OwylTests(unittest.TestCase):
                              blackboard.checkBB(key='value',
                                                 check=checker)
                              )
-        
+
         # Note that we can pass in the blackboard at run-time.
         v = owyl.visit(tree, blackboard=bb)
 
@@ -440,14 +440,14 @@ class OwylTests(unittest.TestCase):
         tree = owyl.repeatUntilSucceed(increment(key='count'))
         v = owyl.visit(tree, blackboard=bb)
         for i in xrange(ticks):
-          v.next()
+            v.next()
         self.assertEqual(bb['count'], ticks)
 
         # Need to reset the blackboard to get the same results.
         bb = blackboard.Blackboard('test', count=0)
         v = owyl.visit(tree, blackboard=bb)
         for i in xrange(ticks):
-          v.next()
+            v.next()
         self.assertEqual(bb['count'], ticks)
 
     def testRepeatUntilFail_Count(self):


### PR DESCRIPTION
I'm kind of new to behavior trees so it'd be nice if someone confirmed whether these failures are real / tests are correct. Though I'm fairly certain repeatUntilSucceed and repeatUntilFail should execute its child more than once to operate correctly.

Here's how the tests fail:

```
FAIL: testParallel_DelayedFailure (__main__.OwylTests)
Can parallel fail if child fails later (all succeed)?
AssertionError: Lists differ: [True] != [False]

FAIL: testParallel_DelayedSuccess (__main__.OwylTests)
Can parallel succeed if child succeeds later (one succeeds)?
AssertionError: Lists differ: [False] != [True]

FAIL: testRepeatAlways_Count (__main__.OwylTests)
Does repeatAlways execute its child with every tick?
AssertionError: 50 != 100

FAIL: testRepeatUntilFail_Count (__main__.OwylTests)
Does repeatUntilFail execute its child with every tick?
AssertionError: 1 != 100

FAIL: testRepeatUntilSucceed_Count (__main__.OwylTests)
Does repeatUntilSucceed execute its child with every tick?
AssertionError: 1 != 100
```
